### PR TITLE
Semicolon fix in infoPlist files

### DIFF
--- a/ios/en.lproj/InfoPlist.strings
+++ b/ios/en.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
   Created by Gian Marco Di Francesco on 22/05/2020.
   Copyright © 2020 The Chromium Authors. All rights reserved.
 */
-NSLocationAlwaysAndWhenInUseUsageDescription = "diAry requests your location when it’s in use and in background in order to track your movements. All information is stored on your device only."
-NSLocationWhenInUseUsageDescription = "diAry requests your location when it’s in use in order to track your movements. All information is stored on your device only."
-NSLocationAlwaysUsageDescription = "diAry requests your location in order to track your movements. All information is stored on your device only."
-NSMotionUsageDescription = "diAry requests your accelerometer data in order to detect your movements and activate location tracking."
+NSLocationAlwaysAndWhenInUseUsageDescription = "diAry requests your location when it’s in use and in background in order to track your movements. All information is stored on your device only.";
+NSLocationWhenInUseUsageDescription = "diAry requests your location when it’s in use in order to track your movements. All information is stored on your device only.";
+NSLocationAlwaysUsageDescription = "diAry requests your location in order to track your movements. All information is stored on your device only.";
+NSMotionUsageDescription = "diAry requests your accelerometer data in order to detect your movements and activate location tracking.";

--- a/ios/it.lproj/InfoPlist.strings
+++ b/ios/it.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
   Created by Gian Marco Di Francesco on 22/05/2020.
   Copyright © 2020 The Chromium Authors. All rights reserved.
 */
-NSLocationAlwaysAndWhenInUseUsageDescription = "diAry richiede l’accesso alla tua posizione geografica quando l’applicazione è attiva ed in background, per tenere traccia dei tuoi movimenti. I dati sono memorizzati esclusivamente sul tuo dispositivo."
-NSLocationWhenInUseUsageDescription = "diAry richiede l’accesso alla tua posizione geografica quando l’applicazione è attiva, per tenere traccia dei tuoi movimenti. I dati sono memorizzati esclusivamente sul tuo dispositivo."
-NSLocationAlwaysUsageDescription = "diAry richiede l’accesso alla tua posizione geografica per tenere traccia dei tuoi movimenti. I dati sono memorizzati esclusivamente sul tuo dispositivo."
-NSMotionUsageDescription = "diAry richiede l’accesso all’accelerometro per rilevare i tuoi spostamenti ed attivare la registrazione della posizione geografica."
+NSLocationAlwaysAndWhenInUseUsageDescription = "diAry richiede l’accesso alla tua posizione geografica quando l’applicazione è attiva ed in background, per tenere traccia dei tuoi movimenti. I dati sono memorizzati esclusivamente sul tuo dispositivo.";
+NSLocationWhenInUseUsageDescription = "diAry richiede l’accesso alla tua posizione geografica quando l’applicazione è attiva, per tenere traccia dei tuoi movimenti. I dati sono memorizzati esclusivamente sul tuo dispositivo.";
+NSLocationAlwaysUsageDescription = "diAry richiede l’accesso alla tua posizione geografica per tenere traccia dei tuoi movimenti. I dati sono memorizzati esclusivamente sul tuo dispositivo.";
+NSMotionUsageDescription = "diAry richiede l’accesso all’accelerometro per rilevare i tuoi spostamenti ed attivare la registrazione della posizione geografica.";


### PR DESCRIPTION
There is an error in localized permission files `ios/en.lproj/InfoPlist.string` and `ios/it.lproj/InfoPlist.string`. Strings do not terminate with a semicolon, following an old standard, causing the build to fail in newer versions of xCode. This fixes the problem.